### PR TITLE
商品詳細表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
-  before_action :move_to_index, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order("created_at DESC")
@@ -18,15 +17,13 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
   
   private
   def item_params
     params.require(:item).permit(:product_name,:image,:explanation,:category_id,:condition_id,:delivery_type_id,:prefecture_id,:shipment_date_id,:cost).merge(user_id:current_user.id)
-  end
-
-  def move_to_index
-    unless user_signed_in?
-      redirect_to action: :index
-    end
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,8 +130,7 @@
     <% if @items.none %> 
       <% @items.each do |item| %>
         <li class='list'>
-          <%# <%= link_to items_path(item.id) do %> 
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %> 
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,38 +4,37 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# if 商品が売れている場合は、sold outを表示しましょう %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.cost %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_type.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -43,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_type.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipment_date.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,8 +7,9 @@
       <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# if 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class:"item-box-img" %>
+      <%#商品が売れている場合 %>
+      <%# if '商品が購入済みである' %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
@@ -23,17 +24,14 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%# 商品が売れていない場合 %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -101,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,8 @@
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-        <%# 商品が売れていない場合 %>
+      <%# 商品が売れていない場合 %>
+      <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
     <%# end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,8 +23,9 @@
         <%= @item.delivery_type.name %>
       </span>
     </div>
-    <%# if user_signed_in? && '商品が出品中である' %>
-      <% if user_signed_in? && current_user.id == @item.user_id %>
+    
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%# if user_signed_in? && '商品が出品中である' %>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
@@ -32,11 +33,11 @@
       <%# 商品が売れていない場合 %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <% end %>
-    <%# end %>
+      <%# end %>
+    <% end %>
     
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,8 +24,8 @@
       </span>
     </div>
     
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%# if user_signed_in? && '商品が出品中である' %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
@@ -33,7 +33,7 @@
       <%# 商品が売れていない場合 %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <%# end %>
+      <% end %>
     <% end %>
     
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,15 +23,16 @@
         <%= @item.delivery_type.name %>
       </span>
     </div>
+    <%# if user_signed_in? && '商品が出品中である' %>
+      <% if user_signed_in? && current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-      <%# 商品が売れていない場合 %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
+        <%# 商品が売れていない場合 %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+    <%# end %>
     
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  get 'items/index'
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
欲しいものについての詳細情報を見て、購入するかしないか判断できるようにするため

### 実装完了画像および動画のURL

>自身が出品した販売中商品の商品詳細ページの遷移動画
https://gyazo.com/e9812a137fee096b5b5c7b4cdb17391f
 
> 自身が出品していない販売中商品の商品詳細ページの遷移動画
https://gyazo.com/15ef0700add68522d3ee21092b7ef675

> 売却済み商品の商品詳細ページ遷移動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能フェーズのレビュー依頼で記載します

>  ログアウト時の商品詳細ページ遷移動画
https://gyazo.com/8921d1d88776ff2eaf068bec8f79f6c4


